### PR TITLE
Also remove explosion knockback resistance

### DIFF
--- a/player_motion/data/player_motion/function/internal/launch/main.mcfunction
+++ b/player_motion/data/player_motion/function/internal/launch/main.mcfunction
@@ -16,6 +16,7 @@ execute \
 
 execute in minecraft:overworld run function player_motion:internal/math/main
 attribute @s knockback_resistance modifier add player_motion:disable_knockback_resistance -1 add_multiplied_total
+attribute @s explosion_knockback_resistance modifier add player_motion:disable_explosion_knockback_resistance -1 add_multiplied_total
 function player_motion:internal/launch/gamemode/get
 gamemode creative
 tp ~ ~10000 ~
@@ -23,6 +24,7 @@ execute rotated as @s positioned ~ ~10000 ~ run function player_motion:internal/
 tp ~ ~ ~
 function player_motion:internal/launch/gamemode/restore
 attribute @s knockback_resistance modifier remove player_motion:disable_knockback_resistance
+attribute @s explosion_knockback_resistance modifier remove player_motion:disable_explosion_knockback_resistance
 
 scoreboard players set $function_called player_motion.internal.dummy 0
 tag @s remove player_motion.launch


### PR DESCRIPTION
An attempt to fix issue #17, making Blast Protection unable to affect motion set by the data pack